### PR TITLE
change order of perl cpan package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,6 @@ RUN \
  cpanm File::Path && \
  cpanm HTML::Entities && \
  cpanm HTML::TableExtract && \
- cpanm HTTP::Cache::Transparent && \
  cpanm inc && \
  cpanm JSON::PP && \
  cpanm LWP::Simple && \
@@ -135,6 +134,7 @@ RUN \
  cpanm version && \
  cpanm WWW::Mechanize && \
  cpanm XML::DOM && \
+ cpanm HTTP::Cache::Transparent && \
 
 # build libiconv
  mkdir -p \
@@ -180,7 +180,7 @@ RUN \
 	--prefix=/usr \
 	--sysconfdir=/config && \
  make && \
- make install && \	
+ make install && \
 
 # build XMLTV
  curl -o /tmp/xmtltv-src.tar.bz2 -L \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ seems switching up the order of the cpanm installs solves the issue of one of them not building.