### PR TITLE
Vaapi support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN \
 	patch \
 	pcre2-dev \
 	perl-dev \
+	pngquant \
 	pkgconf \
 	sdl-dev \
 	uriparser-dev \
@@ -168,6 +169,7 @@ RUN \
 	--disable-hdhomerun_static \
 	--enable-hdhomerun_client \
 	--enable-libav \
+	--enable-pngquant \
 	--enable-vaapi \
 	--infodir=/usr/share/info \
 	--localstatedir=/var \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,14 @@ RUN \
 	git \
 	libgcrypt-dev \
 	libhdhomerun-dev \
-	libressl-dev \
 	libtool \
+	libva-dev \
 	libvpx-dev \
 	libxml2-dev \
 	libxslt-dev \
 	make \
 	mercurial \
+	openssl-dev \
 	opus-dev \
 	patch \
 	pcre2-dev \
@@ -64,12 +65,13 @@ RUN \
 	libcrypto1.0 \
 	libcurl	\
 	libhdhomerun-libs \
-	libressl \
 	libssl1.0 \
+	libva \
 	libvpx \
 	libxml2 \
 	libxslt \
 	linux-headers \
+	openssl \
 	opus \
 	pcre2 \
 	perl \
@@ -146,17 +148,27 @@ RUN \
  git clone https://github.com/tvheadend/tvheadend.git /tmp/tvheadend && \
  cd /tmp/tvheadend && \
  ./configure \
+	`#Encoding` \
 	--disable-ffmpeg_static \
-	--disable-hdhomerun_static \
 	--disable-libfdkaac_static \
-	--disable-libmfx_static \
 	--disable-libtheora_static \
+	--disable-libopus_static \
 	--disable-libvorbis_static \
 	--disable-libvpx_static \
 	--disable-libx264_static \
 	--disable-libx265_static \
+	--disable-libfdkaac \
+	--enable-libopus \
+	--enable-libvorbis \
+	--enable-libvpx \
+	--enable-libx264 \
+	--enable-libx265 \
+	\
+	`#Options` \
+	--disable-hdhomerun_static \
 	--enable-hdhomerun_client \
 	--enable-libav \
+	--enable-vaapi \
 	--infodir=/usr/share/info \
 	--localstatedir=/var \
 	--mandir=/usr/share/man \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN \
 	libxml2-dev \
 	libxslt-dev \
 	make \
-	mercurial \
 	openssl-dev \
 	opus-dev \
 	patch \
@@ -140,11 +139,6 @@ RUN \
  echo "**** install perl modules for xmltv ****" && \
  curl -L http://cpanmin.us | perl - App::cpanminus && \
  cpanm --installdeps /tmp/patches && \
- echo "**** build dvb-apps ****" && \
- hg clone http://linuxtv.org/hg/dvb-apps /tmp/dvb-apps && \
- cd /tmp/dvb-apps && \
- make -C lib && \
- make -C lib install && \
  echo "**** build tvheadend ****" && \
  git clone https://github.com/tvheadend/tvheadend.git /tmp/tvheadend && \
  cd /tmp/tvheadend && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,10 +166,14 @@ RUN \
 	--enable-libx265 \
 	\
 	`#Options` \
+	--disable-avahi \
+	--disable-dbus_1 \
+	--disable-bintray_cache \
 	--disable-hdhomerun_static \
 	--enable-hdhomerun_client \
 	--enable-libav \
 	--enable-pngquant \
+	--enable-trace \
 	--enable-vaapi \
 	--infodir=/usr/share/info \
 	--localstatedir=/var \

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ docker create \
   -e RUN_OPTS=<parameter> \
   -p 9981:9981 \
   -p 9982:9982 \
-  --device=/dev/dvb
+  --device=/dev/dvb \
+  --device=/dev/dri
   linuxserver/tvheadend
 ```
 The --device=/dev/dvb is only needed if you want to pass through a DVB card to the container. If you use IPTV or HDHomeRun you can leave it out.
-
+The --device=/dev/dri is only needed if you want to use your AMD/Intel GPU for hardware accelerated video encoding (vaapi).
 
 You can choose between ,using tags, latest (default, and no tag required or a specific release branch of tvheadend.
 
@@ -68,6 +69,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-e PUID` for UserID - see below for explanation
 * `-e RUN_OPTS` additional runtime parameters - see below for explanation
 * `--device=/dev/dvb` - for passing through DVB-cards
+* `--device=/dev/dri` - for passing through GPU
 * `--net=host` - for IPTV, SAT>IP and HDHomeRun
 * `-e TZ` - for timezone information *eg Europe/London, etc*
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

this is untested as I have no clue about docker (@sparklyballs should know :D )
- adds vaapi transcoding
Its build ffmpeg static into Tvh (via the Tvh buildscript) as the shipped ffmpeg by alpine has no vaapi support, you could ofc build it dynamic but then you have to maintain the building of ffmpeg binary for the system.
You could ofc drop the `ffmpeg` and `ffmpeg-libs` packages to save some size (idk for what they are used at that docker - maybe for piping inside Tvh?). It also changes libressl->openssl as ffmpeg supports no libressl and it is basically useless to patch around here for no benefit.
- png compression of the help pictures, saves some mb without quality loss (backport to 4.2 possible)
- dvb-apps is deprecated, Tvh 4.3-950+ has now its own implementation
- add some build options that might be useful (backport to 4.2 possible)
Pls have a look at the commit, there is it explained.

As said, it builds, but I can't runtime test it at all (missing docker knowhow) :/