### PR TITLE
Give the group abc access to /dev/dvb if exists

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -14,3 +14,5 @@ mkdir -p \
 chown -R abc:abc \
 	/config \
 	/picons
+[[ -d /dev/dvb ]] && \
+	chown -R root:abc /dev/dvb


### PR DESCRIPTION
tvheadend will not be able to use dvb-devices on default.
* Permissions without patch: /dev/dvb (and below) 660 root:root
* Permissions with patch: /dev/dvb (and below) 660 root:abc

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

