### PR TITLE
Add https for curl | perl used for cpanminus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN \
 
 RUN \
  echo "**** install perl modules for xmltv ****" && \
- curl -L http://cpanmin.us | perl - App::cpanminus && \
+ curl -L https://cpanmin.us | perl - App::cpanminus && \
  cpanm --installdeps /tmp/patches
 
 RUN \


### PR DESCRIPTION
I noticed that curl is piped to bash without the use of https during the build. cpanmin.us is also available over https, so it should be used. This PR is not in refenrence to any earlier issue.

I haven't tested this but I can't see any reason for this to not work ;-)
