### PR TITLE
Fix for picons Release 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -318,8 +318,14 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-	/picons/picons.tar.bz2 -L \
-	https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
+        /tmp/picons.tar.bz2 -L \
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
+ tar xf \
+ /tmp/picons.tar.bz2 -C \
+        /picons && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+        /tmp/*
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -321,8 +321,14 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-	/picons/picons.tar.bz2 -L \
-	https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
+        /tmp/picons.tar.bz2 -L \
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
+ tar xf \
+ /tmp/picons.tar.bz2 -C \
+        /picons && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+        /tmp/*
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -321,8 +321,14 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-	/picons/picons.tar.bz2 -L \
-	https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
+        /tmp/picons.tar.bz2 -L \
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
+ tar xf \
+ /tmp/picons.tar.bz2 -C \
+        /picons && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+        /tmp/*
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **14.02.19:** - Add picons path to config.
 * **15.01.19:** - Add pipeline logic and multi arch.
 * **12.09.18:** - Rebase to alpine 3.8 and use buildstage type build.
 * **21.04.18:** - Add JSON::XS Perl package for grab_tv_huro.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -125,6 +125,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "14.02.19:", desc: "Add picons path to config." }
   - { date: "15.01.19:", desc: "Add pipeline logic and multi arch." }
   - { date: "12.09.18:", desc: "Rebase to alpine 3.8 and use buildstage type build." }
   - { date: "21.04.18:", desc: "Add JSON::XS Perl package for grab_tv_huro." }

--- a/root/defaults/config
+++ b/root/defaults/config
@@ -1,5 +1,5 @@
 {
-	"prefer_picon": false,
+	"prefer_picon": true,
 	"chiconpath": "file:///picons/%C.png",
 	"piconpath": "file:///picons/",
 	"piconscheme": 0,

--- a/root/defaults/config
+++ b/root/defaults/config
@@ -1,6 +1,6 @@
 {
 	"prefer_picon": false,
-	"chiconpath": "file://picons/%C.png",
-	"piconpath": "file://picons/",
+	"chiconpath": "file:///picons/%C.png",
+	"piconpath": "file:///picons/",
 	"piconscheme": 0
 }

--- a/root/defaults/config
+++ b/root/defaults/config
@@ -1,0 +1,6 @@
+{
+	"prefer_picon": false,
+	"chiconpath": "file://picons/%C.png",
+	"piconpath": "file://picons/",
+	"piconscheme": 0
+}

--- a/root/defaults/config
+++ b/root/defaults/config
@@ -2,5 +2,6 @@
 	"prefer_picon": false,
 	"chiconpath": "file:///picons/%C.png",
 	"piconpath": "file:///picons/",
-	"piconscheme": 0
+	"piconscheme": 0,
+	"chiconscheme": 2
 }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -9,6 +9,9 @@ mkdir -p \
 	(mkdir -p /config/dvr/config && cp /defaults/7a5edfbe189851e5b1d1df19c93962f0 /config/dvr/config/7a5edfbe189851e5b1d1df19c93962f0)
 [[ ! -e /config/comskip/comskip.ini ]] && \
 	cp /defaults/comskip.ini.org /config/comskip/comskip.ini
+[[ ! -e /config/config ]] && \
+        (cp /defaults/config /config/config)
+
 
 # permissions
 chown -R abc:abc \


### PR DESCRIPTION
So the app has some pretty cool behaviour, on spinup it will add variables to an existing config file if they are missing and needed, likely needed for upgrades and additions. So we can put the bare minimum picons pathing into a config file and have it there on first boot for this container. 

Also added the extraction of the PNGs from the tarball. 