### PR TITLE
libiconv shifted to community repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -315,7 +315,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -109,7 +109,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -314,7 +314,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -109,7 +109,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -314,7 +314,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \


### PR DESCRIPTION
I do not think we need a changelog on a change like this. 