### PR TITLE
libiconv shifted to community repos- release 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -306,7 +306,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -108,7 +108,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -309,7 +309,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -108,7 +108,7 @@ RUN \
 	x265-dev \
 	zlib-dev && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv-dev
 
 RUN \
@@ -309,7 +309,7 @@ RUN \
 	x265 \
 	zlib && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	gnu-libiconv && \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \


### PR DESCRIPTION
I do not think we need a changelog for a change like this. 