### PR TITLE
Extract Tarball on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -320,14 +320,8 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-        /tmp/picons.tar.bz2 -L \
-        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
- tar xf \
- /tmp/picons.tar.bz2 -C \
-        /picons && \
- echo "**** cleanup ****" && \
- rm -rf \
-        /tmp/*
+        /picons.tar.bz2 -L \
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -316,7 +316,7 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-        /tmp/picons.tar.bz2 -L \
+        /picons.tar.bz2 -L \
         https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
 
 # copy local files and buildstage artifacts

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -317,13 +317,7 @@ RUN \
  mkdir -p /picons && \
  curl -o \
         /tmp/picons.tar.bz2 -L \
-        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
- tar xf \
- /tmp/picons.tar.bz2 -C \
-        /picons && \
- echo "**** cleanup ****" && \
- rm -rf \
-        /tmp/*
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -316,7 +316,7 @@ RUN \
  echo "**** Add Picons ****" && \
  mkdir -p /picons && \
  curl -o \
-        /tmp/picons.tar.bz2 -L \
+        /picons.tar.bz2 -L \
         https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
 
 # copy local files and buildstage artifacts

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -317,13 +317,7 @@ RUN \
  mkdir -p /picons && \
  curl -o \
         /tmp/picons.tar.bz2 -L \
-        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2 && \
- tar xf \
- /tmp/picons.tar.bz2 -C \
-        /picons && \
- echo "**** cleanup ****" && \
- rm -rf \
-        /tmp/*
+        https://lsio-ci.ams3.digitaloceanspaces.com/picons/picons.tar.bz2
 
 # copy local files and buildstage artifacts
 COPY --from=buildstage /tmp/argtable-build/usr/ /usr/

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -12,12 +12,17 @@ mkdir -p \
 [[ ! -e /config/config ]] && \
         (cp /defaults/config /config/config)
 
+# extract picons on first run
+[[ -f /picons.tar.bz2 ]] && \
+	tar xf \
+		/picons.tar.bz2 -C \
+		/picons &&
+	rm -f /picons.tar.bz2
 
-
-# function to randomly sample 10 files for their owner and only chown if not abc
+# function to randomly sample 5 files for their owner and only chown if not abc
 chowner () {
 files=(${1}/*)
-for i in {1..10}; do
+for i in {1..5}; do
         user=$(stat -c '%U' $(printf "%s\n" "${files[RANDOM % ${#files[@]}]}"))
         if [ "${user}" != "abc" ]; then
                 chown -R abc:abc ${1}


### PR DESCRIPTION
On AUFS systems this will actually be slightly slower. But overlay2 has been default for some time now and it is painfully slow to initially chown without this. 

Local testing on two overlay2 systems:

SSD x86:
2 seconds for tarball and 18 seconds for the chown logic. 

MicroSD armv7:
8 seconds for tarball and 131 seconds for the chown logic. 

