### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.9 as buildstage
+FROM lsiobase/alpine:3.10 as buildstage
 ############## build stage ##############
 
 # package versions
@@ -220,7 +220,7 @@ RUN \
  make DESTDIR=/tmp/comskip-build install
 
 ############## runtime stage ##############
-FROM lsiobase/alpine:3.9
+FROM lsiobase/alpine:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm64v8-3.9 as buildstage
+FROM lsiobase/alpine:arm64v8-3.10 as buildstage
 ############## build stage ##############
 
 # package versions
@@ -218,7 +218,7 @@ RUN \
  make DESTDIR=/tmp/comskip-build install
 
 ############## runtime stage ##############
-FROM lsiobase/alpine:arm64v8-3.9
+FROM lsiobase/alpine:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm32v7-3.9 as buildstage
+FROM lsiobase/alpine:arm32v7-3.10 as buildstage
 ############## build stage ##############
 
 # package versions
@@ -218,7 +218,7 @@ RUN \
  make DESTDIR=/tmp/comskip-build install
 
 ############## runtime stage ##############
-FROM lsiobase/alpine:arm32v7-3.9
+FROM lsiobase/alpine:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -125,6 +125,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "27.03.19:", desc: "Rebase to Alpine 3.9, fix init logic to only chown once." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "01.03.19:", desc: "Bump xmltv to 0.6.1." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.