### PR TITLE
Fix picons website url

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -117,7 +117,7 @@ app_setup_block: |
 
   **Picons**
 
-  We have added all the picons from [picons.xyz](https://picons.xyz/) in the folder /picons. To enable the use of these picons, add the path to the Channel icon path in Configuration --> General --> Base.
+  We have added all the picons from [picons.eu](https://picons.eu/) in the folder /picons. To enable the use of these picons, add the path to the Channel icon path in Configuration --> General --> Base.
   You need to enable minimum advanced view level to see the picons options.
 
   ## Additional runtime parameters


### PR DESCRIPTION
Use the current new domain of my project picons.eu instead of the outdated picons.xyz