### PR TITLE
Add iHD driver for VAAPI support on newer hardware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,6 +247,7 @@ RUN \
 	libssl1.1 \
 	libva \
 	libva-intel-driver \
+	intel-media-driver \
 	mesa-dri-ati \
 	libvpx \
 	libxml2 \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "11.05.21:", desc: "Added Intel iHD driver support." }
   - { date: "02.06.20:", desc: "Update to Alpine 3.12." }
   - { date: "27.12.19:", desc: "Add requests and perl-json-xs package." }
   - { date: "27.12.19:", desc: "Update to Alpine 3.11." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-tvheadend/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adds iHD driver for using vaapi on newer hardware. Fixes #178 

## Benefits of this PR and context:
Hardware transcoding did not work with the current image on Ubuntu 21.04 and a [Intel NUC 11](https://ark.intel.com/content/www/us/en/ark/products/205040/intel-nuc-11-performance-kit-nuc11pahi5.html)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Rebuild and run container locally and transcoded in tvheadend via pipe.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
N/A
