### PR TITLE
Added details on how to run HDHomeRun without --net=host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you have other host services which also use multicast such as SSDP/DLNA/Emby 
 #### HDHomeRun
 
 You can either run HDHomeRun as --net=host without any additional configuration or within the docker network by specifying the HDHomeRun IP address in Configuration --> General --> Base (Level: Expert).
-In that case you must also specify the Local IP address where the docker is running, and expose the port(s) for the HDHomeRun tuners. See the tooltip of the configuration for details.
+In that case you must also specify the Local IP address where the docker is running, and expose the (udp) port(s) for the HDHomeRun tuners. See the tooltip of the configuration for details.
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,13 @@ docker run -d \
 
 #### Host vs. Bridge
 
-If you use IPTV, SAT>IP or HDHomeRun, you need to create the container with --net=host and remove the -p flags. This is because to work with these services Tvheadend requires a multicast address of `239.255.255.250` and a UDP port of `1900` which at this time is not possible with docker bridge mode.
+If you use IPTV or SAT>IP, you need to create the container with --net=host and remove the -p flags. This is because to work with these services Tvheadend requires a multicast address of `239.255.255.250` and a UDP port of `1900` which at this time is not possible with docker bridge mode.
 If you have other host services which also use multicast such as SSDP/DLNA/Emby you may experience stabilty problems. These can be solved by giving tvheadend its own IP using macvlan.
+
+#### HDHomeRun
+
+You can either run HDHomeRun as --net=host without any additional configuration or within the docker network by specifying the HDHomeRun IP address in Configuration --> General --> Base (Level: Expert).
+In that case you must also specify the Local IP address where the docker is running, and expose the port(s) for the HDHomeRun tuners. See the tooltip of the configuration for details.
 
 ## Parameters
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-tvheadend/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

The current documentation wrongly states that you _must_ run tvheadend in --net=host in order to use HDHomeRun. However, this is incorrect: you can specify the IP in the configuration (expert mode) and it works perfectly well (tested).

## Benefits of this PR and context:

It will help people who want to run this docker without having to be foreced in --net=host mode if they have a HDHomeRun device.

## How Has This Been Tested?

I tested the instructions and they work correctly in my setup.
