### PR TITLE
use optimized libdvbcsa(from glenvt18/libdvbcsa)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,16 @@ RUN \
  make test && \
  make DESTDIR=/tmp/xmltv-build install
 
+ RUN \
+ echo "***** compile libdvbcsa sse2 ****" && \
+ git clone https://github.com/glenvt18/libdvbcsa /tmp/libdvbcsa && \
+ cd /tmp/libdvbcsa && \
+ autoreconf -i && \
+ ./configure \
+	--enable-sse2 && \
+ make -j 2 && \
+ make  install
+
 RUN \
  echo "**** compile tvheadend ****" && \
  if [ -z ${TVHEADEND_COMMIT+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -33,7 +33,6 @@ RUN \
 	gzip \
 	jq \
 	libcurl \
-	libdvbcsa-dev \
 	libgcrypt-dev \
 	libhdhomerun-dev \
 	libtool \
@@ -136,6 +135,16 @@ RUN \
  make -j 2 && \
  make test && \
  make DESTDIR=/tmp/xmltv-build install
+
+RUN \
+ echo "***** compile libdvbcsa neon ****" && \
+ git clone https://github.com/glenvt18/libdvbcsa /tmp/libdvbcsa && \
+ cd /tmp/libdvbcsa && \
+ autoreconf -i && \
+ ./configure \
+	--enable-neon && \
+ make -j 2 && \
+ make  install
 
 RUN \
  echo "**** compile tvheadend ****" && \
@@ -245,7 +254,6 @@ RUN \
 	gzip \
 	libcrypto1.1 \
 	libcurl \
-	libdvbcsa \
 	libhdhomerun-libs \
 	libssl1.1 \
 	libvpx \
@@ -324,6 +332,7 @@ COPY --from=buildstage /tmp/xmltv-build/usr/ /usr/
 COPY --from=buildstage /usr/local/share/man/ /usr/local/share/man/
 COPY --from=buildstage /usr/local/share/perl5/ /usr/local/share/perl5/
 COPY --from=piconsstage /picons.tar.bz2 /picons.tar.bz2
+COPY --from=buildstage /usr/local/lib/libdvbcsa* /usr/local/lib/
 COPY root/ /
 
 # ports and volumes

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -33,7 +33,6 @@ RUN \
 	gzip \
 	jq \
 	libcurl \
-	libdvbcsa-dev \
 	libgcrypt-dev \
 	libhdhomerun-dev \
 	libtool \
@@ -136,6 +135,16 @@ RUN \
  make -j 2 && \
  make test && \
  make DESTDIR=/tmp/xmltv-build install
+
+RUN \
+ echo "***** compile libdvbcsa neon ****" && \
+ git clone https://github.com/glenvt18/libdvbcsa /tmp/libdvbcsa && \
+ cd /tmp/libdvbcsa && \
+ autoreconf -i && \
+ ./configure \
+	--enable-neon && \
+ make -j 2 && \
+ make  install
 
 RUN \
  echo "**** compile tvheadend ****" && \
@@ -246,7 +255,6 @@ RUN \
 	gzip \
 	libcrypto1.1 \
 	libcurl \
-	libdvbcsa \
 	libhdhomerun-libs \
 	libssl1.1 \
 	libvpx \
@@ -325,6 +333,7 @@ COPY --from=buildstage /tmp/xmltv-build/usr/ /usr/
 COPY --from=buildstage /usr/local/share/man/ /usr/local/share/man/
 COPY --from=buildstage /usr/local/share/perl5/ /usr/local/share/perl5/
 COPY --from=piconsstage /picons.tar.bz2 /picons.tar.bz2
+COPY --from=buildstage /usr/local/lib/libdvbcsa* /usr/local/lib/
 COPY root/ /
 
 # ports and volumes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [yes ] I have read the [contributing](https://github.com/linuxserver/docker-tvheadend/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
there exist a optimized libdvbcsa which speeds up encrypted streams a lot (especially on arm32v7 and aarch64)

## Benefits of this PR and context:
on x86_64 i used the sse2 option which is mandatory on x64 ( there are ssse3 and avx2 options too )
on arm32v7 and aarch64 the neon extension  which is mandatory on aarch64  and on arm32v7 not but most arm32v7 have it except some nvidie cpus(tegra 2) , if this is a problem the option can be disabled on arm32v7  and it still will be faster than orginal libdvbcsa  

Benefits: less cpu usage on encrpted streams 

## How Has This Been Tested?
 tested on allwiner h3  cpu before 10 - 12 load per stream   after 4-5 %
 on https://github.com/pykpkg47/docker-tvheadend_image_mod/pkgs/container/tvheadend you can find 
 docker images with the pr to test it yourself



## Source / References:
https://tvheadend.org/boards/13/topics/35411
https://github.com/glenvt18/libdvbcsa
